### PR TITLE
Release 2.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 # SDK version property
-SDK_VERSION_NAME=2.1.0
+SDK_VERSION_NAME=2.1.1


### PR DESCRIPTION
## Issues
[Push services initialisation bug #245](https://github.com/mindbox-moscow/issues-mobile-sdk/issues/245)
New method `Mindbox.initPushServices(Context, List<MindboxPushService>)` was added. This method is required in order to show push messages when application is not loaded. This method must be called in your `Application` class in `onCreate()` ONLY IF you call `Mindbox.init()` is some other place (for example, in activity).

---

[Send InfoUpdated event on initPushServices called #250](https://github.com/mindbox-moscow/issues-mobile-sdk/issues/250)
Event InfoUpdated will be sent on `initPushServices()` invocation when push token was changed