### PR TITLE
Set version to 2.1.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 # SDK version property
-SDK_VERSION_NAME=2.1.2
+SDK_VERSION_NAME=2.1.3


### PR DESCRIPTION
# What's new:

## Issues
[SDK reinitialization #246](https://github.com/mindbox-moscow/issues-mobile-sdk/issues/246)
This feature allows you to change your domain, endpoint and shouldCreateCustomer parameters in existing SDK integration. New parameters need to be specified in `Configuration` passed to `Mindbox.init()`. 
- If Mindbox SDK detects, that domain or endpoint changed, it would be treated as a fresh installation: an ApplicationInstalled (or ApplicationInstalledWithoutCustomer) event will be sent, all previously stored events will not be sent. 
- If shouldCreateCustomer was changed from `false` to `true`, ApplicationInstalled will be sent and all previously stored events will not be sent. 
- If shouldCreateCustomer was changed from `true` to `false`, all previously stored events will not be sent