### PR TITLE
MOBILE-52: Fix snackbar cross and cross margins

### DIFF
--- a/sdk/src/main/java/cloud/mindbox/mobile_sdk/Extensions.kt
+++ b/sdk/src/main/java/cloud/mindbox/mobile_sdk/Extensions.kt
@@ -150,7 +150,7 @@ internal val Int.px: Int
     get() = (this * Resources.getSystem().displayMetrics.density).roundToInt()
 
 internal fun Context.maxScreenDimension(): Int {
-    val displayMetrics = resources.displayMetrics
+    val displayMetrics = applicationContext.resources.displayMetrics
     return maxOf(displayMetrics.widthPixels, displayMetrics.heightPixels)
 }
 

--- a/sdk/src/main/java/cloud/mindbox/mobile_sdk/inapp/presentation/view/InAppConstraintLayout.kt
+++ b/sdk/src/main/java/cloud/mindbox/mobile_sdk/inapp/presentation/view/InAppConstraintLayout.kt
@@ -7,6 +7,7 @@ import android.view.*
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.FrameLayout
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.*
 import cloud.mindbox.mobile_sdk.SnackbarPosition
 import cloud.mindbox.mobile_sdk.inapp.domain.models.InAppType
@@ -291,4 +292,16 @@ internal data class InAppInsets(
 
 internal fun interface BackButtonLayout {
     fun setBackListener(listener: (() -> Unit)?)
+}
+
+/**
+ * Clones the current constraint state, applies [block] to it, then commits the result back.
+ * Removes the clone/applyTo boilerplate from call sites.
+ */
+internal fun InAppConstraintLayout.updateConstraints(block: ConstraintSet.() -> Unit) {
+    ConstraintSet().apply {
+        clone(this@updateConstraints)
+        block()
+        applyTo(this@updateConstraints)
+    }
 }

--- a/sdk/src/main/java/cloud/mindbox/mobile_sdk/inapp/presentation/view/InAppCrossView.kt
+++ b/sdk/src/main/java/cloud/mindbox/mobile_sdk/inapp/presentation/view/InAppCrossView.kt
@@ -2,18 +2,19 @@ package cloud.mindbox.mobile_sdk.inapp.presentation.view
 
 import android.content.Context
 import android.graphics.Canvas
-import android.graphics.Color
 import android.graphics.Paint
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintSet
+import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import cloud.mindbox.mobile_sdk.inapp.domain.models.Element
 import cloud.mindbox.mobile_sdk.inapp.domain.models.Element.CloseButton.Position.Kind.PROPORTION
 import cloud.mindbox.mobile_sdk.inapp.domain.models.Element.CloseButton.Size.Kind.DP
-import cloud.mindbox.mobile_sdk.logger.mindboxLogD
 import cloud.mindbox.mobile_sdk.px
 import kotlin.math.roundToInt
+import androidx.core.graphics.toColorInt
+import cloud.mindbox.mobile_sdk.logger.mindboxLogI
 
 internal class InAppCrossView : View {
 
@@ -76,32 +77,21 @@ internal class InAppCrossView : View {
         updateLayoutParams {
             width = crossWidth
             height = crossHeight
-            paint.color = Color.parseColor(closeButtonElement.color)
+            paint.color = closeButtonElement.color.toColorInt()
         }
-        val constraintSet = ConstraintSet()
-        val marginTop =
-            ((currentDialog.height - crossHeight) * closeButtonElement.position.top).roundToInt()
-        val marginEnd =
-            ((currentDialog.width - crossWidth) * closeButtonElement.position.right).roundToInt()
+        currentDialog.doOnLayout {
+            val marginTop =
+                ((currentDialog.height - crossHeight) * closeButtonElement.position.top).roundToInt()
+            val marginEnd =
+                ((currentDialog.width - crossWidth) * closeButtonElement.position.right).roundToInt()
 
-        constraintSet.clone(currentDialog)
-        constraintSet.connect(
-            id,
-            ConstraintSet.TOP,
-            currentDialog.id,
-            ConstraintSet.TOP,
-            marginTop
-        )
-        constraintSet.connect(
-            id,
-            ConstraintSet.END,
-            currentDialog.id,
-            ConstraintSet.END,
-            marginEnd
-        )
-        constraintSet.applyTo(currentDialog)
-        mindboxLogD("InApp cross is shown with params:color = ${closeButtonElement.color}, lineWidth = ${closeButtonElement.lineWidth}, width = ${closeButtonElement.size.width}, height = ${closeButtonElement.size.height} with kind ${closeButtonElement.size.kind.name}. Margins: top = ${closeButtonElement.position.top}, bottom = ${closeButtonElement.position.bottom}, left = ${closeButtonElement.position.left}, right = ${closeButtonElement.position.right} and kind ${closeButtonElement.position.kind.name}")
-        if (paint.strokeWidth == 0f || crossWidth == 0 || crossHeight == 0) isVisible = false
+            currentDialog.updateConstraints {
+                connect(id, ConstraintSet.TOP, currentDialog.id, ConstraintSet.TOP, marginTop)
+                connect(id, ConstraintSet.END, currentDialog.id, ConstraintSet.END, marginEnd)
+            }
+            mindboxLogI("InApp cross is shown with params:color = ${closeButtonElement.color}, lineWidth = ${closeButtonElement.lineWidth}, width = ${closeButtonElement.size.width}, height = ${closeButtonElement.size.height} with kind ${closeButtonElement.size.kind.name}. Margins: top = ${closeButtonElement.position.top}, bottom = ${closeButtonElement.position.bottom}, left = ${closeButtonElement.position.left}, right = ${closeButtonElement.position.right} and kind ${closeButtonElement.position.kind.name}")
+            if (paint.strokeWidth == 0f || crossWidth == 0 || crossHeight == 0) isVisible = false
+        }
     }
 
     fun prepareViewForModalWindow(currentDialog: InAppConstraintLayout) {

--- a/sdk/src/main/java/cloud/mindbox/mobile_sdk/inapp/presentation/view/InAppImageView.kt
+++ b/sdk/src/main/java/cloud/mindbox/mobile_sdk/inapp/presentation/view/InAppImageView.kt
@@ -1,7 +1,6 @@
 package cloud.mindbox.mobile_sdk.inapp.presentation.view
 
 import android.content.Context
-import android.widget.FrameLayout
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
@@ -24,7 +23,7 @@ internal class InAppImageView(context: Context) : AppCompatImageView(context) {
         val oneThirdScreenHeight = resources.displayMetrics.heightPixels / 3
         val desiredHeight =
             (((resources.displayMetrics.widthPixels.toDouble() - marginStart.toDouble() - marginEnd.toDouble()) / (size.width.toDouble())) * size.height).roundToInt()
-        layoutParams = FrameLayout.LayoutParams(
+        layoutParams = ConstraintLayout.LayoutParams(
             ConstraintLayout.LayoutParams.MATCH_PARENT,
             if (desiredHeight > oneThirdScreenHeight) oneThirdScreenHeight else desiredHeight
         )
@@ -36,38 +35,13 @@ internal class InAppImageView(context: Context) : AppCompatImageView(context) {
             width = 0.dp
             height = 0.dp
         }
-        val constraintSet = ConstraintSet()
-        constraintSet.clone(currentDialog)
-        constraintSet.setDimensionRatio(id, MODAL_WINDOW_ASPECT_RATIO)
         scaleType = ScaleType.CENTER_CROP
-        constraintSet.connect(
-            id,
-            ConstraintSet.TOP,
-            currentDialog.id,
-            ConstraintSet.TOP,
-            0
-        )
-        constraintSet.connect(
-            id,
-            ConstraintSet.END,
-            currentDialog.id,
-            ConstraintSet.END,
-            0
-        )
-        constraintSet.connect(
-            id,
-            ConstraintSet.START,
-            currentDialog.id,
-            ConstraintSet.START,
-            0
-        )
-        constraintSet.connect(
-            id,
-            ConstraintSet.BOTTOM,
-            currentDialog.id,
-            ConstraintSet.BOTTOM,
-            0
-        )
-        constraintSet.applyTo(currentDialog)
+        currentDialog.updateConstraints {
+            setDimensionRatio(id, MODAL_WINDOW_ASPECT_RATIO)
+            connect(id, ConstraintSet.TOP, currentDialog.id, ConstraintSet.TOP, 0)
+            connect(id, ConstraintSet.END, currentDialog.id, ConstraintSet.END, 0)
+            connect(id, ConstraintSet.START, currentDialog.id, ConstraintSet.START, 0)
+            connect(id, ConstraintSet.BOTTOM, currentDialog.id, ConstraintSet.BOTTOM, 0)
+        }
     }
 }

--- a/sdk/src/test/java/cloud/mindbox/mobile_sdk/inapp/data/managers/InAppGlideImageLoaderImplTest.kt
+++ b/sdk/src/test/java/cloud/mindbox/mobile_sdk/inapp/data/managers/InAppGlideImageLoaderImplTest.kt
@@ -62,6 +62,7 @@ internal class InAppGlideImageLoaderImplTest {
             widthPixels = 1080
             heightPixels = 1920
         }
+        every { context.applicationContext } returns context
         every { context.resources } returns resources
         every { resources.displayMetrics } returns displayMetrics
         every { context.getString(R.string.mindbox_inapp_fetching_timeout) } returns "3000"


### PR DESCRIPTION
https://tracker.yandex.ru/MOBILE-52

InAppImageView.kt — fix ClassCastException in snackbar: used FrameLayout.LayoutParams on a ConstraintLayout child; switched to ConstraintLayout.LayoutParams.

InAppCrossView.kt — fix close button stuck in corner: margins were computed from currentDialog.height/width which are 0 before layout. Wrapped margin calc + constraints in doOnLayout {} (works for both sync cache-hit and async paths).

Extensions.kt — fix Glide cache-key mismatch on foldables/multi-display: maxScreenDimension() returned different metrics for Application vs Activity context → different .override() → cache miss. Now always reads from applicationContext.